### PR TITLE
Make Rewarding Snipes Relic Carts not die at sea

### DIFF
--- a/ids.h
+++ b/ids.h
@@ -211,6 +211,7 @@ static const int ID_HENRY_V = 847;
 static const int ID_DINH_LE = 1184; 
 static const int CLASS_PETARD = 35;
 static const int CLASS_HERO = 25;
+static const int CLASS_RELIC = 45;
 
 
 static const int CLASS_TRANSPORT_BOAT = 20;

--- a/patches/rewarding_snipes.cpp
+++ b/patches/rewarding_snipes.cpp
@@ -9,6 +9,7 @@ void configureRewardingSnipes(genie::DatFile *df) {
         std::cout << "Patched King blood unit for civ " << civ.Name << "\n";
 
         genie::Unit &relicCart = civ.Units.at(ID_RELIC_CART);
+        relicCart.Class = CLASS_RELIC; //don't die at sea
         relicCart.FogVisibility = 1; //always visible
         relicCart.HitPoints = 30000; //don't die from exploding kings
 


### PR DESCRIPTION
Giving relic class keeps things from dying at sea